### PR TITLE
Add Mailbox Forwarding Report

### DIFF
--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -742,6 +742,11 @@ export const nativeMenuItems = [
             permissions: ["Exchange.Mailbox.*"],
           },
           {
+            title: "Mailbox Forwarding",
+            path: "/email/reports/mailbox-forwarding",
+            permissions: ["Exchange.Mailbox.*"],
+          },
+          {
             title: "Anti-Phishing Filters",
             path: "/email/reports/antiphishing-filters",
             permissions: ["Exchange.SpamFilter.*"],

--- a/src/pages/email/reports/mailbox-forwarding/index.js
+++ b/src/pages/email/reports/mailbox-forwarding/index.js
@@ -37,6 +37,7 @@ const Page = () => {
   ];
 
   const apiData = {
+    UseReportDB: true,
     ForwardingOnly: forwardingOnly,
   };
 

--- a/src/pages/email/reports/mailbox-forwarding/index.js
+++ b/src/pages/email/reports/mailbox-forwarding/index.js
@@ -1,0 +1,124 @@
+import { Layout as DashboardLayout } from "../../../../layouts/index.js";
+import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
+import { useState } from "react";
+import {
+  Button,
+  FormControlLabel,
+  Switch,
+  Alert,
+  SvgIcon,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import { useSettings } from "../../../../hooks/use-settings";
+import { Stack } from "@mui/system";
+import { Sync, Info } from "@mui/icons-material";
+import { useDialog } from "../../../../hooks/use-dialog";
+import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog";
+import { CippQueueTracker } from "../../../../components/CippTable/CippQueueTracker";
+
+const Page = () => {
+  const [forwardingOnly, setForwardingOnly] = useState(true);
+  const currentTenant = useSettings().currentTenant;
+  const syncDialog = useDialog();
+  const [syncQueueId, setSyncQueueId] = useState(null);
+
+  const isAllTenants = currentTenant === "AllTenants";
+
+  const columns = [
+    ...(isAllTenants ? ["Tenant"] : []),
+    "UPN",
+    "DisplayName",
+    "RecipientTypeDetails",
+    "ForwardingType",
+    "ForwardTo",
+    "DeliverToMailboxAndForward",
+    "CacheTimestamp",
+  ];
+
+  const apiData = {
+    ForwardingOnly: forwardingOnly,
+  };
+
+  const pageActions = [
+    <Stack direction="row" spacing={2} alignItems="center" key="actions-stack">
+      <CippQueueTracker
+        queueId={syncQueueId}
+        queryKey={`mailbox-forwarding-${currentTenant}-${forwardingOnly}`}
+        title="Mailbox Forwarding Sync"
+      />
+      <Tooltip title="This report displays cached mailbox data from the CIPP reporting database. Cache timestamps are shown in the table. Click the Sync button to update the mailbox cache for the current tenant.">
+        <IconButton size="small">
+          <Info fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Button
+        startIcon={
+          <SvgIcon fontSize="small">
+            <Sync />
+          </SvgIcon>
+        }
+        size="xs"
+        onClick={syncDialog.handleOpen}
+        disabled={isAllTenants}
+      >
+        Sync
+      </Button>
+      <FormControlLabel
+        key="forwardingOnly"
+        control={
+          <Switch
+            checked={forwardingOnly}
+            onChange={(e) => setForwardingOnly(e.target.checked)}
+            color="primary"
+          />
+        }
+        label="Forwarding Only"
+        labelPlacement="start"
+      />
+    </Stack>,
+  ];
+
+  return (
+    <>
+      {currentTenant && currentTenant !== "" ? (
+        <CippTablePage
+          key={`mailbox-forwarding-${forwardingOnly}`}
+          title="Mailbox Forwarding Report"
+          apiUrl="/api/ListMailboxForwarding"
+          queryKey={`mailbox-forwarding-${currentTenant}-${forwardingOnly}`}
+          apiData={apiData}
+          simpleColumns={columns}
+          cardButton={pageActions}
+          offCanvas={null}
+        />
+      ) : (
+        <Alert severity="warning">Please select a tenant to view mailbox forwarding settings.</Alert>
+      )}
+      <CippApiDialog
+        createDialog={syncDialog}
+        title="Sync Mailbox Cache"
+        fields={[]}
+        api={{
+          type: "GET",
+          url: "/api/ExecCIPPDBCache",
+          confirmText: `Run mailbox cache sync for ${currentTenant}? This will update mailbox data including forwarding settings.`,
+          relatedQueryKeys: [`mailbox-forwarding-${currentTenant}-${forwardingOnly}`],
+          data: {
+            Name: "Mailboxes",
+            Types: "",
+          },
+          onSuccess: (result) => {
+            if (result?.Metadata?.QueueId) {
+              setSyncQueueId(result.Metadata.QueueId);
+            }
+          },
+        }}
+      />
+    </>
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;


### PR DESCRIPTION
## Summary

- Add new Mailbox Forwarding report page under Email & Exchange > Reports
- Displays mailbox forwarding settings (external, internal, or both) from cached mailbox data
- Includes "Forwarding Only" toggle to filter to only mailboxes with forwarding configured
- Follows the same patterns as Calendar Permissions and Mailbox Permissions reports

## Changes

- `src/pages/email/reports/mailbox-forwarding/index.js` - New report page with sync button, queue tracker, and toggle
- `src/layouts/config.js` - Added menu entry for Mailbox Forwarding under Email Reports

## Test plan

- [ ] Select a tenant and navigate to Email & Exchange > Reports > Mailbox Forwarding
- [ ] Verify the report loads with cached data (requires mailbox cache to be synced)
- [ ] Toggle "Forwarding Only" to filter results
- [ ] Test Sync button to refresh mailbox cache
- [ ] Verify AllTenants view works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)