### PR TITLE
Add Create CA Policy Type button for ITGlue field mapping

### DIFF
--- a/src/components/CippIntegrations/CippIntegrationFieldMapping.jsx
+++ b/src/components/CippIntegrations/CippIntegrationFieldMapping.jsx
@@ -10,13 +10,14 @@ import {
 } from "@mui/material";
 import CippFormSection from "../CippFormPages/CippFormSection";
 import { useForm } from "react-hook-form";
-import { ApiGetCall } from "../../api/ApiCall";
+import { ApiGetCall, ApiPostCall } from "../../api/ApiCall";
 import { useRouter } from "next/router";
 import extensions from "../../data/Extensions.json";
 import React, { useEffect, useState } from "react";
 import CippFormComponent from "../CippComponents/CippFormComponent";
-import { Sync } from "@mui/icons-material";
+import { Sync, Add } from "@mui/icons-material";
 import { Stack, Grid } from "@mui/system";
+import { CippApiResults } from "../CippComponents/CippApiResults";
 
 const CippIntegrationFieldMapping = () => {
   const router = useRouter();
@@ -35,6 +36,17 @@ const CippIntegrationFieldMapping = () => {
 
   const extension = extensions.find((extension) => extension.id === router.query.id);
   const [missingMappings, setMissingMappings] = useState([]);
+
+  const createCATypePostCall = ApiPostCall({
+    relatedQueryKeys: [`IntegrationFieldMapping-${router.query.id}`],
+  });
+
+  const handleCreateCAType = () => {
+    createCATypePostCall.mutate({
+      url: `/api/ExecExtensionMapping?CreateCAType=${router.query.id}`,
+      data: {},
+    });
+  };
 
   useEffect(() => {
     if (fieldMapping.isSuccess) {
@@ -96,7 +108,19 @@ const CippIntegrationFieldMapping = () => {
                     </Typography>
                   </Box>
                   {headerIndex === 0 && (
-                    <Box>
+                    <Stack direction="row" spacing={1}>
+                      {router.query.id === "ITGlue" && (
+                        <Tooltip title="Create the M365 Conditional Access Policy flexible asset type in ITGlue">
+                          <Button
+                            onClick={handleCreateCAType}
+                            variant="outlined"
+                            disabled={createCATypePostCall.isPending}
+                            startIcon={<Add />}
+                          >
+                            Create CA Policy Type
+                          </Button>
+                        </Tooltip>
+                      )}
                       <Tooltip title="Refresh Mappings">
                         <Button
                           onClick={() => {
@@ -107,9 +131,14 @@ const CippIntegrationFieldMapping = () => {
                           <Sync />
                         </Button>
                       </Tooltip>
-                    </Box>
+                    </Stack>
                   )}
                 </Stack>
+                {headerIndex === 0 && router.query.id === "ITGlue" && (
+                  <Box sx={{ my: 2 }}>
+                    <CippApiResults apiObject={createCATypePostCall} />
+                  </Box>
+                )}
                 <Divider />
                 <Grid container spacing={3} sx={{ my: 3 }}>
                   {fieldMapping?.data?.CIPPFields?.filter(


### PR DESCRIPTION
## Summary
- Add UI button in the ITGlue field mapping page to create the M365 Conditional Access Policy flexible asset type
- Button only appears when configuring ITGlue integration
- Calls new `CreateCAType=ITGlue` API endpoint
- Displays success/error feedback using CippApiResults component

## Test plan
- [ ] Navigate to Settings > Integrations > ITGlue > Field Mapping
- [ ] Verify "Create CA Policy Type" button appears next to Refresh button
- [ ] Click button and verify success message is displayed
- [ ] Click Refresh and verify the new type appears in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)