### PR TITLE
Add AppManagementPolicy standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -1344,6 +1344,88 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.AppManagementPolicy",
+    "cat": "Entra (AAD) Standards",
+    "tag": [],
+    "helpText": "Configures the default app management policy to control application and service principal credential restrictions such as password and key credential lifetimes.",
+    "docsDescription": "Configures the default app management policy to control application and service principal credential restrictions. This includes password addition restrictions, custom password addition, symmetric key addition, and credential lifetime limits for both applications and service principals.",
+    "executiveText": "Enforces credential restrictions on application registrations and service principals to limit how secrets and certificates are created and how long they remain valid. This reduces the risk of long-lived or unmanaged credentials being used to access your tenant.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": false,
+        "name": "standards.AppManagementPolicy.passwordCredentialsPasswordAddition",
+        "label": "Password Addition",
+        "options": [
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      },
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": false,
+        "name": "standards.AppManagementPolicy.passwordCredentialsCustomPasswordAddition",
+        "label": "Custom Password Addition",
+        "options": [
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      },
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": false,
+        "name": "standards.AppManagementPolicy.keyCredentialsSymmetricKeyAddition",
+        "label": "Symmetric Key Addition",
+        "options": [
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      },
+      {
+        "type": "number",
+        "required": false,
+        "name": "standards.AppManagementPolicy.passwordCredentialsMaxLifetime",
+        "label": "Password Credentials Max Lifetime (Days)"
+      },
+      {
+        "type": "number",
+        "required": false,
+        "name": "standards.AppManagementPolicy.keyCredentialsMaxLifetime",
+        "label": "Key Credentials Max Lifetime (Days)"
+      }
+    ],
+    "label": "Set Default App Management Policy",
+    "impact": "Medium Impact",
+    "impactColour": "warning",
+    "addedDate": "2026-03-13",
+    "powershellEquivalent": "Graph API",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.OutBoundSpamAlert",
     "cat": "Exchange Standards",
     "tag": ["CIS M365 5.0 (2.1.6)"],


### PR DESCRIPTION
Introduce a new Entra (AAD) standard entry 'standards.AppManagementPolicy' to src/data/standards.json. Adds UI configuration for default app management policy to control application and service principal credential restrictions (password addition, custom password addition, symmetric key addition) and numeric fields for password/key credential max lifetimes. Includes metadata (label, impact, impactColour, addedDate) and a PowerShell/Graph API equivalence note. This enables configuring credential creation rules and lifetime limits to reduce risk from long-lived or unmanaged credentials.