### PR TITLE
Remove duplicate custom password option

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -1375,25 +1375,7 @@
         "creatable": false,
         "required": false,
         "name": "standards.AppManagementPolicy.passwordCredentialsCustomPasswordAddition",
-        "label": "Custom Password Addition",
-        "options": [
-          {
-            "label": "Enabled",
-            "value": "enabled"
-          },
-          {
-            "label": "Disabled",
-            "value": "disabled"
-          }
-        ]
-      },
-      {
-        "type": "autoComplete",
-        "multiple": false,
-        "creatable": false,
-        "required": false,
-        "name": "standards.AppManagementPolicy.keyCredentialsSymmetricKeyAddition",
-        "label": "Symmetric Key Addition",
+        "label": "Custom Password",
         "options": [
           {
             "label": "Enabled",


### PR DESCRIPTION
Delete the standalone standards.AppManagementPolicy.passwordCredentialsCustomPasswordAddition entry and rename standards.AppManagementPolicy.keyCredentialsSymmetricKeyAddition label from "Symmetric Key Addition" to "Custom Password" to consolidate the custom password option into a single field.